### PR TITLE
Use schema uid as element key chmjs/chameleon-builder#6

### DIFF
--- a/src/mixins/elementable.js
+++ b/src/mixins/elementable.js
@@ -90,10 +90,12 @@ export default {
     renderChildren() {
       const children = this.config.elements;
       return map(children, (child) => {
+        const key = child._schema ? child._schema.uid : uuid();
+
         const el = this.$createElement(
           this.getElementTag(child.type),
           {
-            key: `${child.type}_${uuid()}`,
+            key: `${child.type}_${key}`,
             staticClass: `${this.$options.name}-item`,
             props: {
               definition: child,


### PR DESCRIPTION
If child element has `_schema` prop, use it as element key, otherwise, generate uuid.