### PR TITLE
Support dynamic reference #6

### DIFF
--- a/src/mixins/bindable.js
+++ b/src/mixins/bindable.js
@@ -9,30 +9,28 @@ export default {
     Currently it only supports resolving references from store.
     */
     getBindingValue(value) {
-      if (isNil(this.registry)) {
+      if (isNil(this.registry) || !startsWith(value, '=')) {
         return value;
       }
 
-      if (startsWith(value, '=')) {
-        let binding = value.substring(1);
+      let binding = value.substring(1);
 
-        /*
-        For source of binding use registry or entire store.
-        If there is a $ reference then use store first.
-        If there is no $ reference then look in bindableElements registry.
-        */
-        let source = this.registry.bindableElements;
-        if (startsWith(binding, '$')) {
-          source = isNil(this.$store) ? this.registry : this.$store;
-          binding = binding.substring(1);
-        }
+      /*
+      For source of binding use registry or entire store.
+      If there is a $ reference then use store first.
+      If there is no $ reference then look in bindableElements registry.
+      */
+      let source = this.registry.bindableElements;
+      if (startsWith(binding, '$')) {
+        source = isNil(this.$store) ? this.registry : this.$store;
+        binding = binding.substring(1);
+      }
 
-        if (source) {
-          return binding.split('.').reduce((o, i) => {
-            if (o[i]) return o[i];
-            return value;
-          }, source);
-        }
+      if (source) {
+        return binding.split('.').reduce((o, i) => {
+          if (o[i]) return o[i];
+          return value;
+        }, source);
       }
 
       return value;

--- a/src/mixins/bindable.js
+++ b/src/mixins/bindable.js
@@ -2,18 +2,37 @@ import { isNil, startsWith } from 'lodash';
 
 export default {
   methods: {
+    /*
+    Resolves dynamic value.
+    Dynamic value must start with equal (=) sign.
+    If we detect dollar ($) sign after we try to resolve reference.
+    Currently it only supports resolving references from store.
+    */
     getBindingValue(value) {
       if (isNil(this.registry)) {
         return value;
       }
 
-      const elements = this.registry.bindableElements;
-      if (elements && startsWith(value, '=')) {
-        const binding = value.substring(1);
-        return binding.split('.').reduce((o, i) => {
-          if (o[i]) return o[i];
-          return value;
-        }, elements);
+      if (startsWith(value, '=')) {
+        let binding = value.substring(1);
+
+        /*
+        For source of binding use registry or entire store.
+        If there is a $ reference then use store first.
+        If there is no $ reference then look in bindableElements registry.
+        */
+        let source = this.registry.bindableElements;
+        if (startsWith(binding, '$')) {
+          source = isNil(this.$store) ? this.registry : this.$store;
+          binding = binding.substring(1);
+        }
+
+        if (source) {
+          return binding.split('.').reduce((o, i) => {
+            if (o[i]) return o[i];
+            return value;
+          }, source);
+        }
       }
 
       return value;

--- a/src/mixins/bindable.spec.js
+++ b/src/mixins/bindable.spec.js
@@ -3,7 +3,18 @@ import elementable from './elementable';
 import bindable from './bindable';
 
 const localVue = createLocalVue();
+
+/*
+Fake store just to test dynamic
+reference resolve.
+*/
 localVue.prototype.$chameleon = {
+  app: {
+    pages: [
+      { name: 'Page A' },
+      { name: 'Page B' },
+    ],
+  },
   bindableElements: {
     element: {
       myDynamicProp: 'HelloBindable',
@@ -63,6 +74,12 @@ describe('bindable mixin', () => {
     const value = '=element.dataSource.myDynamicProp';
     const bindingValue = wrapper.vm.getBindingValue(value);
     expect(bindingValue).toEqual('HelloBindableSource');
+  });
+
+  it('resolves dynamic reference', () => {
+    const value = '=$app.pages';
+    const bindingValue = wrapper.vm.getBindingValue(value);
+    expect(bindingValue).toHaveLength(2);
   });
 
   it('resolves with empty registry', () => {


### PR DESCRIPTION
This PR adds support for resolving dynamic references in form `=$myObject.myProperty`. `myObject` in this example must be property of store (or registry if store is not available like in mocks). In future we can also support some other references (outside of store) if needed.

Resolves #6