### PR TITLE
Feature/connector instances

### DIFF
--- a/src/api/connector/external/wordpress.js
+++ b/src/api/connector/external/wordpress.js
@@ -24,9 +24,9 @@ const getChangeMethod = (options) => {
 
 export default {
   changeSourceData(connector, source, options) {
-    const url = `${getBaseUrl(connector)}/${source.name}`;
+    const url = `${getBaseUrl(connector.type)}/${source.name}`;
     const method = getChangeMethod(options);
-    return http[method](url, assign(getCommonMeta(), options.payload)).then((response) => {
+    return http[method](url, assign(getCommonMeta(connector), options.payload)).then((response) => {
       const result = response.data;
       return result;
     });
@@ -40,7 +40,7 @@ export default {
   },
   getSourceData(connector, source, options) {
     const url = `${getBaseUrl(connector.type)}/${source.name}`;
-    return http.get(url, assign(getCommonMeta(), {
+    return http.get(url, assign(getCommonMeta(connector), {
       params: options.params,
     })).then((response) => {
       const result = response.data;

--- a/src/api/connector/external/wordpress.js
+++ b/src/api/connector/external/wordpress.js
@@ -32,8 +32,8 @@ export default {
     });
   },
   getSources(connector) {
-    const url = getBaseUrl(connector);
-    return http.get(url, getCommonMeta()).then((response) => {
+    const url = getBaseUrl(connector.type);
+    return http.get(url, getCommonMeta(connector)).then((response) => {
       const result = response.data;
       return result.sources;
     });
@@ -48,8 +48,8 @@ export default {
     });
   },
   getSourceSchema(connector, source) {
-    const url = `${getBaseUrl(connector)}/${source.name}/schema`;
-    return http.get(url, getCommonMeta()).then((response) => {
+    const url = `${getBaseUrl(connector.type)}/${source.name}/schema`;
+    return http.get(url, getCommonMeta(connector)).then((response) => {
       const result = response.data;
       return result;
     });

--- a/src/api/connector/external/wordpress.js
+++ b/src/api/connector/external/wordpress.js
@@ -39,7 +39,7 @@ export default {
     });
   },
   getSourceData(connector, source, options) {
-    const url = `${getBaseUrl(connector)}/${source.name}`;
+    const url = `${getBaseUrl(connector.type)}/${source.name}`;
     return http.get(url, assign(getCommonMeta(), {
       params: options.params,
     })).then((response) => {

--- a/src/api/connector/external/wordpress.spec.js
+++ b/src/api/connector/external/wordpress.spec.js
@@ -6,11 +6,15 @@ import postsMock from 'data/wordpress-posts.json';
 import wordpress from './wordpress';
 
 const connectorMock = {
-  name: 'wordpress',
-  type: 'rest',
-  disabled: false,
-  options: {
-    endpoint: null,
+  id: '1234',
+  name: 'Test Wordpress',
+  type: {
+    name: 'wordpress',
+    type: 'rest',
+    disabled: false,
+    options: {
+      endpoint: null,
+    },
   },
 };
 
@@ -29,7 +33,7 @@ describe('wordpress connector', () => {
     }));
 
     const options = {};
-    wordpress.getSources(connectorMock, options).then((result) => {
+    wordpress.getSources(connectorMock.type, options).then((result) => {
       expect(result).toEqual(sourcesMock.sources);
       done();
     });
@@ -41,7 +45,7 @@ describe('wordpress connector', () => {
     }));
 
     const options = {};
-    wordpress.getSourceSchema(connectorMock, options).then((result) => {
+    wordpress.getSourceSchema(connectorMock.type, options).then((result) => {
       expect(result).toEqual(postsSchemaMock);
       done();
     });

--- a/src/api/connector/external/wordpress.spec.js
+++ b/src/api/connector/external/wordpress.spec.js
@@ -33,7 +33,7 @@ describe('wordpress connector', () => {
     }));
 
     const options = {};
-    wordpress.getSources(connectorMock.type, options).then((result) => {
+    wordpress.getSources(connectorMock, options).then((result) => {
       expect(result).toEqual(sourcesMock.sources);
       done();
     });
@@ -45,7 +45,7 @@ describe('wordpress connector', () => {
     }));
 
     const options = {};
-    wordpress.getSourceSchema(connectorMock.type, options).then((result) => {
+    wordpress.getSourceSchema(connectorMock, options).then((result) => {
       expect(result).toEqual(postsSchemaMock);
       done();
     });

--- a/src/api/connector/index.js
+++ b/src/api/connector/index.js
@@ -9,6 +9,7 @@ const parseSourceData = (connector, source, options, data) => {
 
   const result = {
     connector: {
+      id: connector.id,
       name: connector.name,
       type: connector.type,
     },
@@ -56,12 +57,12 @@ export default {
     return type;
   },
   getSources(connector) {
-    const connectorType = this.getConnectorType(connector);
-    return connectorType.getSources(connector);
+    const connectorType = this.getConnectorType(connector.type);
+    return connectorType.getSources(connector.type);
   },
   getSourceData(connector, source, options) {
     const opts = isNil(options) ? {} : options;
-    const connectorType = this.getConnectorType(connector);
+    const connectorType = this.getConnectorType(connector.type);
 
     return connectorType.getSourceData(connector, source, opts).then((data) => {
       const result = parseSourceData(connector, source, opts, data);
@@ -69,7 +70,7 @@ export default {
     });
   },
   getSourceSchema(connector, source) {
-    const connectorType = this.getConnectorType(connector);
-    return connectorType.getSourceSchema(connector, source);
+    const connectorType = this.getConnectorType(connector.type);
+    return connectorType.getSourceSchema(connector.type, source);
   },
 };

--- a/src/api/connector/index.js
+++ b/src/api/connector/index.js
@@ -58,7 +58,7 @@ export default {
   },
   getSources(connector) {
     const connectorType = this.getConnectorType(connector.type);
-    return connectorType.getSources(connector.type);
+    return connectorType.getSources(connector);
   },
   getSourceData(connector, source, options) {
     const opts = isNil(options) ? {} : options;
@@ -71,6 +71,6 @@ export default {
   },
   getSourceSchema(connector, source) {
     const connectorType = this.getConnectorType(connector.type);
-    return connectorType.getSourceSchema(connector.type, source);
+    return connectorType.getSourceSchema(connector, source);
   },
 };

--- a/src/api/connector/index.js
+++ b/src/api/connector/index.js
@@ -11,7 +11,7 @@ const parseSourceData = (connector, source, options, data) => {
     connector: {
       id: connector.id,
       name: connector.name,
-      type: connector.type,
+      type: connector.type.name,
     },
     name: source.name,
     model: source.model,
@@ -26,8 +26,9 @@ const parseSourceData = (connector, source, options, data) => {
 const parseChangeSourceData = (connector, source, options, data) => {
   const result = {
     connector: {
+      id: connector.id,
       name: connector.name,
-      type: connector.type,
+      type: connector.type.name,
     },
     name: source.name,
     model: source.model,

--- a/src/api/connector/index.spec.js
+++ b/src/api/connector/index.spec.js
@@ -20,17 +20,23 @@ axiosMock.get.mockImplementation(() => Promise.resolve({
 }));
 
 const connectorMock = {
-  name: 'local',
-  type: 'internalLocal',
-  description: 'Local Connector',
-  disabled: false,
-  options: {
-    endpoint: 'https://chameleon.nsoft.com/static/data',
+  name: 'My local',
+  id: '1334',
+  type: {
+    name: 'local',
+    type: 'internalLocal',
+    description: 'Local Connector',
+    disabled: false,
+    options: {
+      endpoint: 'https://chameleon.nsoft.com/static/data',
+    },
+    schema: null,
+    multipleInstances: false,
   },
   sources: {
     populationPerAge: {
       name: 'populationPerAge',
-      model: 'PopulationPerAge',
+      model: 'populationPerAge',
     },
   },
 };

--- a/src/api/connector/internal/graphql.js
+++ b/src/api/connector/internal/graphql.js
@@ -153,7 +153,7 @@ export default {
     return http.post(url, {
       query: getQuery(source),
       variables: options.params,
-    }, getCommonMeta()).then((response) => {
+    }, getCommonMeta(connector)).then((response) => {
       const result = response.data.data;
       return result;
     });

--- a/src/api/connector/internal/graphql.js
+++ b/src/api/connector/internal/graphql.js
@@ -34,7 +34,7 @@ const getQuery = (source) => {
   const params = getQueryParams(source);
   const pagination = params.pagination || '';
 
-  return `query ${name}${params.args} { 
+  return `query ${name}${params.args} {
     ${name}${params.bindings} {
       items {
         ${getQueryFields(source)}
@@ -148,7 +148,8 @@ export default {
     });
   },
   getSourceData(connector, source, options) {
-    const url = `${connector.options.endpoint}/${connector.name}`;
+    const connectorType = connector.type;
+    const url = `${connectorType.options.endpoint}/${connectorType.name}`;
     return http.post(url, {
       query: getQuery(source),
       variables: options.params,

--- a/src/api/connector/internal/graphql.js
+++ b/src/api/connector/internal/graphql.js
@@ -110,13 +110,14 @@ export default {
     throw new Error(`Method changeSourceData is not implemented on ${connector.name} connector!`);
   },
   getSources(connector) {
-    const url = `${connector.options.endpoint}/${connector.name}`;
+    const connectorType = connector.type;
+    const url = `${connectorType.options.endpoint}/${connectorType.name}`;
     return http.post(url, {
       query: getSchemaTypeQuery(),
       variables: {
         name: 'Query',
       },
-    }, getCommonMeta()).then((response) => {
+    }, getCommonMeta(connector)).then((response) => {
       const data = getRootType(response);
       const sources = {};
 
@@ -159,13 +160,14 @@ export default {
     });
   },
   getSourceSchema(connector, source) {
-    const url = `${connector.options.endpoint}/${connector.name}`;
+    const connectorType = connector.type;
+    const url = `${connectorType.options.endpoint}/${connectorType.name}`;
     return http.post(url, {
       query: getSchemaTypeQuery(),
       variables: {
         name: source.model,
       },
-    }, getCommonMeta()).then((response) => {
+    }, getCommonMeta(connector)).then((response) => {
       const data = getRootType(response);
       const schema = [];
 

--- a/src/api/connector/internal/graphql.spec.js
+++ b/src/api/connector/internal/graphql.spec.js
@@ -4,11 +4,13 @@ import sourcesMock from 'data/graphql-sources.json';
 import graphql from './graphql';
 
 const connectorMock = {
-  name: 'chameleon',
-  type: 'graphql',
-  disabled: false,
-  options: {
-    endpoint: null,
+  type: {
+    name: 'chameleon',
+    type: 'graphql',
+    disabled: false,
+    options: {
+      endpoint: null,
+    },
   },
 };
 

--- a/src/api/connector/internal/local.js
+++ b/src/api/connector/internal/local.js
@@ -8,15 +8,14 @@ import http from 'axios';
 
 export default {
   getSources(connector) {
-    const url = `${connector.options.endpoint}/sources.json`;
+    const url = `${connector.type.options.endpoint}/sources.json`;
     return http.get(url).then((response) => {
       const result = response.data;
       return result;
     });
   },
   getSourceData(connector, source) {
-    const connectorType = connector.type;
-    const url = `${connectorType.options.endpoint}/${source.name}.json`;
+    const url = `${connector.type.options.endpoint}/${source.name}.json`;
     return http.get(url).then((response) => {
       const result = response.data;
       return {
@@ -27,7 +26,7 @@ export default {
     });
   },
   getSourceSchema(connector, source) {
-    const url = `${connector.options.endpoint}/sourceSchema.json`;
+    const url = `${connector.type.options.endpoint}/sourceSchema.json`;
     return http.get(url).then((response) => {
       const result = response.data;
       return result[source.model];

--- a/src/api/connector/internal/local.js
+++ b/src/api/connector/internal/local.js
@@ -15,7 +15,8 @@ export default {
     });
   },
   getSourceData(connector, source) {
-    const url = `${connector.options.endpoint}/${source.name}.json`;
+    const connectorType = connector.type;
+    const url = `${connectorType.options.endpoint}/${source.name}.json`;
     return http.get(url).then((response) => {
       const result = response.data;
       return {

--- a/src/api/connector/utility.js
+++ b/src/api/connector/utility.js
@@ -2,12 +2,16 @@ import { isNil } from 'lodash';
 import { localStorage } from '../../utility';
 
 /* eslint import/prefer-default-export:"off" */
-export function getCommonMeta() {
+export function getCommonMeta(connector) {
   const token = localStorage.getAuthToken();
   const headers = {};
 
   if (!isNil(token)) {
     headers.authorization = `Bearer ${token}`;
+  }
+
+  if (connector) {
+    headers['X-NSFT-CONNECTOR-INSTANCE'] = connector.id;
   }
 
   return {

--- a/src/mixins/sourceable.js
+++ b/src/mixins/sourceable.js
@@ -49,7 +49,7 @@ export default {
         const connector = assign(
           {},
           this.dataConnector,
-          this.options.connectors[this.dataConnector.name],
+          this.options.connectors[this.dataConnector.id],
         );
 
         const source = merge({}, {

--- a/src/mixins/sourceable.spec.js
+++ b/src/mixins/sourceable.spec.js
@@ -18,18 +18,24 @@ axiosMock.get.mockImplementation(() => Promise.resolve({
 }));
 
 const connectors = {
-  local: {
-    name: 'local',
-    type: 'internalLocal',
-    description: 'Local Connector',
-    disabled: false,
-    options: {
-      endpoint: 'https://chameleon.nsoft.com/static/data',
+  1334: {
+    name: 'My local',
+    id: '1334',
+    type: {
+      name: 'local',
+      type: 'internalLocal',
+      description: 'Local Connector',
+      disabled: false,
+      options: {
+        endpoint: 'https://chameleon.nsoft.com/static/data',
+      },
+      schema: null,
+      multipleInstances: false,
     },
     sources: {
       populationPerAge: {
         name: 'populationPerAge',
-        model: 'PopulationPerAge',
+        model: 'populationPerAge',
       },
     },
   },
@@ -65,8 +71,19 @@ let wrapper = shallowMount(component, {
         name: 'populationPerAge',
         model: 'PopulationPerAge',
         connector: {
-          name: 'local',
-          type: 'internalLocal',
+          id: '1334',
+          name: 'My local',
+          type: {
+            name: 'local',
+            type: 'internalLocal',
+            description: 'Local Connector',
+            disabled: false,
+            options: {
+              endpoint: 'https://chameleon.nsoft.com/static/data',
+            },
+            schema: null,
+            multipleInstances: false,
+          },
         },
         /* We are switching property names to check mapping */
         schema: [
@@ -99,7 +116,7 @@ describe('sourceable mixin', () => {
   });
 
   it('sets exact dataConnector', () => {
-    expect(wrapper.vm.dataConnector.type).toEqual('internalLocal');
+    expect(wrapper.vm.dataConnector.type.type).toEqual('internalLocal');
   });
 
   it('loads data from remote', (done) => {


### PR DESCRIPTION
Change connector handling for data and source schema fetching.

Connector instance is passed as connector parameter. Every instance has `type` property which contains connector type data (which was previously passed).
`X-NSFT-CONNECTOR-INSTANCE` header is added as common meta to each request.