### PR TITLE
Remove unneeded mapped original values

### DIFF
--- a/src/mixins/reactionable.spec.js
+++ b/src/mixins/reactionable.spec.js
@@ -100,7 +100,6 @@ describe('reactionable mixin', () => {
     expect(spy).toHaveBeenCalled();
     expect(wrapper.vm.myActionResult).toEqual({
       payload: {
-        field: true,
         mapField: true,
       },
       data: {

--- a/src/mixins/reactionable.spec.js
+++ b/src/mixins/reactionable.spec.js
@@ -101,7 +101,6 @@ describe('reactionable mixin', () => {
     expect(wrapper.vm.myActionResult).toEqual({
       payload: {
         field: true,
-        field_$: true,
         mapField: true,
       },
       data: {

--- a/src/mixins/sourceable.spec.js
+++ b/src/mixins/sourceable.spec.js
@@ -130,6 +130,8 @@ describe('sourceable mixin', () => {
       expect(result.name).toBeTruthy();
       expect(result.model).toBeTruthy();
       expect(result.schema instanceof Array).toBeTruthy();
+      expect(result.schema[1].mapName).toEqual('age');
+      expect(result.schema[2].mapName).toBeUndefined();
       expect(result.items.length).toBeGreaterThan(0);
       expect(result.items[0].population).toEqual('<5');
       expect(keys(result.items[0]).length).toEqual(3);

--- a/src/mixins/sourceable.spec.js
+++ b/src/mixins/sourceable.spec.js
@@ -1,4 +1,5 @@
 import axiosMock from 'axios';
+import { keys } from 'lodash';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import { connector } from '../api';
 import bindable from './bindable';
@@ -7,13 +8,13 @@ import sourceable from './sourceable';
 
 axiosMock.get.mockImplementation(() => Promise.resolve({
   data: [
-    { population: 2704659, age: '<5' },
-    { population: 4499890, age: '5-13' },
-    { population: 2159981, age: '14-17' },
-    { population: 3853788, age: '18-24' },
-    { population: 14106543, age: '25-44' },
-    { population: 8819342, age: '45-64' },
-    { population: 1712463, age: '≥65' },
+    { population: 2704659, age: '<5', active: true },
+    { population: 4499890, age: '5-13', active: true },
+    { population: 2159981, age: '14-17', active: true },
+    { population: 3853788, age: '18-24', active: false },
+    { population: 14106543, age: '25-44', active: false },
+    { population: 8819342, age: '45-64', active: true },
+    { population: 1712463, age: '≥65', active: true },
   ],
 }));
 
@@ -99,6 +100,11 @@ let wrapper = shallowMount(component, {
             label: 'Population',
             mapName: 'age',
           },
+          {
+            name: 'active',
+            type: 'Boolean',
+            label: 'Active',
+          },
         ],
       },
     },
@@ -126,6 +132,7 @@ describe('sourceable mixin', () => {
       expect(result.schema instanceof Array).toBeTruthy();
       expect(result.items.length).toBeGreaterThan(0);
       expect(result.items[0].population).toEqual('<5');
+      expect(keys(result.items[0]).length).toEqual(3);
       done();
     });
   });

--- a/src/utility/mapping.js
+++ b/src/utility/mapping.js
@@ -31,6 +31,8 @@ const mapItem = (schema, item) => {
       if (!isSwitch) {
         delete item[field.name];
       }
+    } else {
+      field.mapName = field.name;
     }
 
     delete item[`${field.name}${originalSuffix}`];

--- a/src/utility/mapping.js
+++ b/src/utility/mapping.js
@@ -31,8 +31,6 @@ const mapItem = (schema, item) => {
       if (!isSwitch) {
         delete item[field.name];
       }
-    } else {
-      field.mapName = field.name;
     }
 
     delete item[`${field.name}${originalSuffix}`];

--- a/src/utility/mapping.js
+++ b/src/utility/mapping.js
@@ -22,8 +22,15 @@ const mapItem = (schema, item) => {
   });
 
   each(schema, (field) => {
+    let isSwitch = false;
+
     if (field.mapName) {
+      isSwitch = !isNil(item[field.mapName]);
       item[field.mapName] = clone(item[`${field.name}${originalSuffix}`]);
+
+      if (!isSwitch) {
+        delete item[field.name];
+      }
     }
 
     delete item[`${field.name}${originalSuffix}`];

--- a/src/utility/mapping.js
+++ b/src/utility/mapping.js
@@ -1,4 +1,5 @@
 import {
+  clone,
   each,
   find,
   isArray,
@@ -8,16 +9,24 @@ import {
 
 const originalSuffix = '_$';
 
+/*
+There is a lot of cloning here to handle mapping.
+When implementing nesting we need to use cloneDeep.
+This method should be optimized if possible as it
+would be slow on large datasets. Test performance.
+*/
 const mapItem = (schema, item) => {
   /* eslint no-param-reassign:"off" */
   each(schema, (field) => {
-    item[`${field.name}${originalSuffix}`] = item[field.name];
+    item[`${field.name}${originalSuffix}`] = clone(item[field.name]);
   });
 
   each(schema, (field) => {
     if (field.mapName) {
-      item[field.mapName] = item[`${field.name}${originalSuffix}`];
+      item[field.mapName] = clone(item[`${field.name}${originalSuffix}`]);
     }
+
+    delete item[`${field.name}${originalSuffix}`];
   });
 
   return item;


### PR DESCRIPTION
This PR removes original properties copied for mapping purpose. 
This leaves mapped object clean. 
Ref https://github.com/chmjs/chameleon-vuetify/issues/45