### PR TITLE
Feature/application connector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.68",
+  "version": "1.0.70",
   "description": "Chameleon Software Development Kit",
   "author": "Chameleon Team <chameleon@nsoft.com>",
   "contributors": [

--- a/src/api/connector/index.js
+++ b/src/api/connector/index.js
@@ -57,6 +57,9 @@ export default {
     });
   },
   getConnectorType(connector) {
+    console.log(connector);
+    console.log('TYPEs', connectorTypes);
+
     const type = connectorTypes[connector.type];
     return type;
   },
@@ -73,6 +76,7 @@ export default {
     });
   },
   getSourceSchema(connector, source) {
+    console.log('SUP', connector);
     const connectorType = this.getConnectorType(connector.type);
     return connectorType.getSourceSchema(connector, source);
   },

--- a/src/api/connector/index.js
+++ b/src/api/connector/index.js
@@ -57,9 +57,6 @@ export default {
     });
   },
   getConnectorType(connector) {
-    console.log(connector);
-    console.log('TYPEs', connectorTypes);
-
     const type = connectorTypes[connector.type];
     return type;
   },
@@ -76,7 +73,6 @@ export default {
     });
   },
   getSourceSchema(connector, source) {
-    console.log('SUP', connector);
     const connectorType = this.getConnectorType(connector.type);
     return connectorType.getSourceSchema(connector, source);
   },

--- a/src/api/connector/internal/application.js
+++ b/src/api/connector/internal/application.js
@@ -1,0 +1,80 @@
+const sourceSchemas = {
+  currentApp: {
+    name: 'currentApp',
+    model: 'CurrentApp',
+    actions: ['read'],
+    identifier: 'id',
+    fields: [
+      {
+        name: 'id',
+        type: 'String',
+      },
+    ],
+    filters: {
+      operators: ['eq'],
+      fields: {
+        id: '*',
+      },
+    },
+  },
+  currentUser: {
+    name: 'currentUser',
+    model: 'CurrentUser',
+    actions: ['read'],
+    identifier: 'id',
+    fields: [
+      {
+        name: 'id',
+        type: 'String',
+      },
+    ],
+    filters: {
+      operators: ['eq'],
+    },
+  },
+  pages: {
+    name: 'pages',
+    model: 'Pages',
+    actions: ['read'],
+    identifier: 'id',
+    fields: [
+      {
+        name: 'name',
+        type: 'String',
+      },
+      {
+        name: 'path',
+        type: 'String',
+      },
+      {
+        name: 'description',
+        type: 'String',
+      },
+      {
+        name: '_id',
+        type: 'String',
+      },
+    ],
+    filters: {
+      operators: ['eq'],
+    },
+  },
+};
+
+export default {
+  getSources(connector, { savedOnly }) {
+    console.log(connector, savedOnly);
+
+    return true;
+  },
+  getSourceData(connector, source) {
+    console.log(connector, source);
+
+    return true;
+  },
+  getSourceSchema(connector, source) {
+    return new Promise((resolve) => {
+      resolve(sourceSchemas[source.name]);
+    });
+  },
+};

--- a/src/api/connector/internal/application.js
+++ b/src/api/connector/internal/application.js
@@ -141,7 +141,9 @@ export default {
   async getSourceSchema(connector, source) {
     return new Promise((resolve, reject) => {
       if (sourceSchemas[source.name]) {
-        return resolve(sourceSchemas[source.name]);
+        return resolve({
+          schema: sourceSchemas[source.name],
+        });
       }
 
       logger.error('Non-existent source schema');

--- a/src/api/connector/internal/application.js
+++ b/src/api/connector/internal/application.js
@@ -124,7 +124,12 @@ export default {
     return getSavedSources(connector);
   },
   async getSourceData(connector, source, options) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
+      if (!sourceMeta[source.name] || !sourceSchemas[source.name]) {
+        logger.error('Non-existent source schema or meta');
+        return reject(new Error('Non-existent source schema or meta'));
+      }
+
       const { context, path, parse } = sourceMeta[source.name];
 
       const data = binding.resolveDynamicValue(path, {
@@ -147,7 +152,7 @@ export default {
       }
 
       logger.error('Non-existent source schema');
-      return reject();
+      return reject(new Error('Non-existent source schema'));
     });
   },
 };

--- a/src/api/connector/internal/application.js
+++ b/src/api/connector/internal/application.js
@@ -1,3 +1,6 @@
+import { getSavedSources } from '../common';
+import { logger } from '../../../utility';
+
 const sourceSchemas = {
   currentApp: {
     name: 'currentApp',
@@ -62,19 +65,20 @@ const sourceSchemas = {
 };
 
 export default {
-  getSources(connector, { savedOnly }) {
-    console.log(connector, savedOnly);
-
-    return true;
+  getSources(connector) {
+    return getSavedSources(connector);
   },
-  getSourceData(connector, source) {
-    console.log(connector, source);
-
+  getSourceData() {
     return true;
   },
   getSourceSchema(connector, source) {
-    return new Promise((resolve) => {
-      resolve(sourceSchemas[source.name]);
+    return new Promise((resolve, reject) => {
+      if (sourceSchemas) {
+        return resolve(sourceSchemas[source.name]);
+      }
+
+      logger.error('Non-existent source schema');
+      return reject();
     });
   },
 };

--- a/src/api/connector/internal/application.js
+++ b/src/api/connector/internal/application.js
@@ -131,8 +131,6 @@ export default {
         [context]: options.context[context],
       });
 
-      console.log('DATA', data);
-
       return resolve({
         [source.name]: {
           items: parse ? parse(data) : data,

--- a/src/api/connector/internal/application.js
+++ b/src/api/connector/internal/application.js
@@ -13,6 +13,10 @@ const sourceSchemas = {
         name: 'id',
         type: 'String',
       },
+      {
+        name: 'name',
+        type: 'String',
+      },
     ],
     filters: {
       operators: ['eq'],
@@ -25,10 +29,10 @@ const sourceSchemas = {
     name: 'currentUser',
     model: 'CurrentUser',
     actions: ['read'],
-    identifier: 'id',
+    identifier: 'email',
     fields: [
       {
-        name: 'id',
+        name: 'email',
         type: 'String',
       },
     ],
@@ -38,7 +42,7 @@ const sourceSchemas = {
   },
   pages: {
     name: 'pages',
-    model: 'Pages',
+    model: 'Page',
     actions: ['read'],
     identifier: 'id',
     fields: [
@@ -59,25 +63,45 @@ const sourceSchemas = {
       operators: ['eq'],
     },
   },
+  themes: {
+    name: 'themes',
+    model: 'Theme',
+    actions: ['read'],
+    identifier: 'id',
+    fields: [
+      {
+        name: 'name',
+        type: 'String',
+      },
+      {
+        name: 'value',
+        type: 'String',
+      },
+    ],
+    filters: {
+      operators: ['eq'],
+    },
+  },
 };
 
 const sourceMeta = {
   currentApp: {
     context: 'registry',
-    path: '=$app.id',
-    parse(appId) {
+    path: '=$app',
+    parse(app) {
       return [{
-        id: appId,
+        id: app.id,
+        name: app.name,
       }];
     },
   },
   currentUser: {
     context: 'registry',
     path: '=$app.users',
-    parse(users) {
-      return map(users, userId => ({
-        id: userId,
-      }));
+    parse(email) {
+      return [{
+        email,
+      }];
     },
   },
   pages: {
@@ -88,6 +112,10 @@ const sourceMeta = {
 
       return map(pages, page => pick(page, schemaFields));
     },
+  },
+  themes: {
+    context: 'registry',
+    path: '=$themes',
   },
 };
 
@@ -107,7 +135,7 @@ export default {
 
       return resolve({
         [source.name]: {
-          items: parse(data),
+          items: parse ? parse(data) : data,
         },
       });
     });

--- a/src/api/connector/internal/application.spec.js
+++ b/src/api/connector/internal/application.spec.js
@@ -1,4 +1,35 @@
+/* eslint import/no-unresolved:"off" */
+import axiosMock from 'axios';
+import sourceSchemaMock from 'data/application-source-schema.json';
 import application from './application';
+
+
+const connectorInstanceMock = {
+  global: true,
+  id: 'application',
+  name: 'Application',
+  type: 'internalApplication',
+  options: {},
+  sources: {
+    currentApp: {
+      name: 'currentApp',
+      model: 'CurrentApp',
+    },
+    currentUser: {
+      name: 'currentUser',
+      model: 'CurrentUser',
+    },
+    pages: {
+      name: 'pages',
+      model: 'Page',
+    },
+    themes: {
+      name: 'themes',
+      model: 'Theme',
+    },
+  },
+};
+
 
 describe('application connector', () => {
   it('should have methods exposed', () => {
@@ -7,4 +38,49 @@ describe('application connector', () => {
     expect(typeof application.getSourceSchema).toEqual(compareType);
     expect(typeof application.getSourceData).toEqual(compareType);
   });
+
+  it('should get sources', (done) => {
+    axiosMock.get.mockImplementation(() => Promise.resolve({
+      data: connectorInstanceMock.sources,
+    }));
+
+
+    application.getSources(connectorInstanceMock).then((result) => {
+      expect(result).toEqual(connectorInstanceMock.sources);
+      done();
+    });
+  });
+
+  it('should get source schema', (done) => {
+    axiosMock.get.mockImplementation(() => Promise.resolve({
+      data: sourceSchemaMock,
+    }));
+
+    const sourceMock = {
+      name: 'pages',
+    };
+
+    application.getSourceSchema(connectorInstanceMock, sourceMock).then((result) => {
+      expect(result).toEqual(sourceSchemaMock);
+      done();
+    });
+  });
+  //
+  // it('should get source data', (done) => {
+  //   axiosMock.get.mockImplementation(() => Promise.resolve({
+  //     data: sourceDataMock.seedResponse,
+  //   }));
+  //
+  //   const options = {
+  //     seed: true,
+  //     params: {
+  //       pageSize: 15,
+  //     },
+  //   };
+  //
+  //   rest.getSourceData(connectorMock, sourceMock, options).then((result) => {
+  //     expect(result).toEqual(sourceDataMock.seedResult);
+  //     done();
+  //   });
+  // });
 });

--- a/src/api/connector/internal/application.spec.js
+++ b/src/api/connector/internal/application.spec.js
@@ -74,12 +74,13 @@ describe('application connector', () => {
     const sourceMock = {
       name: 'pages',
     };
-
-    const result = await application.getSourceData(connectorInstanceMock, sourceMock, {
+    const optionsMock = {
       context: {
         registry: sourceRegistryMock,
       },
-    });
+    };
+
+    const result = await application.getSourceData(connectorInstanceMock, sourceMock, optionsMock);
 
     expect(result).toEqual(sourceDataMock);
     done();

--- a/src/api/connector/internal/application.spec.js
+++ b/src/api/connector/internal/application.spec.js
@@ -1,0 +1,10 @@
+import application from './application';
+
+describe('application connector', () => {
+  it('should have methods exposed', () => {
+    const compareType = 'function';
+    expect(typeof application.getSources).toEqual(compareType);
+    expect(typeof application.getSourceSchema).toEqual(compareType);
+    expect(typeof application.getSourceData).toEqual(compareType);
+  });
+});

--- a/src/api/connector/internal/index.js
+++ b/src/api/connector/internal/index.js
@@ -1,3 +1,4 @@
 export { default as internalGraphql } from './graphql';
 export { default as internalRest } from './rest';
 export { default as internalLocal } from './local';
+export { default as internalApplication } from './application';

--- a/src/mixins/sourceable.js
+++ b/src/mixins/sourceable.js
@@ -38,6 +38,10 @@ export default {
       return {
         params: merge(this.dataSourceParams, this.dataSource.params),
         seed: this.registry.isPreviewMode,
+        context: {
+          registry: this.registry,
+          parent: this.$parent,
+        },
       };
     },
     loadConnectorData() {

--- a/test/__data__/application-source-data.json
+++ b/test/__data__/application-source-data.json
@@ -1,0 +1,21 @@
+{
+  "pages": {
+    "items": [
+      {
+        "_id": null,
+        "name": "Home",
+        "path": "/"
+      },
+      {
+        "_id": null,
+        "name": "About",
+        "path": "/about"
+      },
+      {
+        "_id": "contact",
+        "name": "Contact",
+        "path": "/contact"
+      }
+    ]
+  }
+}

--- a/test/__data__/application-source-registry.json
+++ b/test/__data__/application-source-registry.json
@@ -1,0 +1,21 @@
+{
+  "app": {
+    "pages": [
+      {
+        "_id": null,
+        "name": "Home",
+        "path": "/"
+      },
+      {
+        "_id": null,
+        "name": "About",
+        "path": "/about"
+      },
+      {
+        "_id": "contact",
+        "name": "Contact",
+        "path": "/contact"
+      }
+    ]
+  }
+}

--- a/test/__data__/application-source-schema.json
+++ b/test/__data__/application-source-schema.json
@@ -1,0 +1,21 @@
+{
+  "schema": {
+    "name": "pages",
+    "model": "Page",
+    "actions": ["read"],
+    "identifier": "id",
+    "fields": [{
+      "name": "name",
+      "type": "String"
+    }, {
+      "name": "path",
+      "type": "String"
+    }, {
+      "name": "_id",
+      "type": "String"
+    }],
+    "filters": {
+      "operators": ["eq"]
+    }
+  }
+}


### PR DESCRIPTION
Resolves #15.

Implemented application connector, with read methods for this `registry` data: `currentApp`, `currentUser`, `themes`, `pages`.

Parent data source is something which I would like to take more time to think about, since it has some unique quirks when compared to other ones. It can be done in next iteration.

Also, did kind of a switch to async-await.

