### PR TITLE
Expose all local storage keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/utility/localStorage.js
+++ b/src/utility/localStorage.js
@@ -43,6 +43,13 @@ export default {
 
     return header;
   },
+  getAllKeys() {
+    if (this.isSupported) {
+      return Object.keys(localStorage);
+    }
+
+    return null;
+  },
   getItem(key) {
     if (this.isSupported) {
       return localStorage.getItem(key);

--- a/src/utility/localStorage.spec.js
+++ b/src/utility/localStorage.spec.js
@@ -20,7 +20,7 @@ describe('localStorage utility', () => {
     expect(storage.getItem('test')).toEqual('testValue');
   });
 
-  it('should save get storage keys', () => {
+  it('should get storage keys', () => {
     storage.setItem('test', 'testValue');
     expect(storage.getAllKeys()).toEqual(['test']);
   });

--- a/src/utility/localStorage.spec.js
+++ b/src/utility/localStorage.spec.js
@@ -20,6 +20,11 @@ describe('localStorage utility', () => {
     expect(storage.getItem('test')).toEqual('testValue');
   });
 
+  it('should save get storage keys', () => {
+    storage.setItem('test', 'testValue');
+    expect(storage.getAllKeys()).toEqual(['test']);
+  });
+
   it('should remove data', () => {
     storage.setItem('test', 'testValue');
     expect(storage.removeItem('test')).toBeFalsy();


### PR DESCRIPTION
I need access to storage keys, so I could delete the ones that are no longer active (deleted apps)

ref #chmjs/chameleon-builder/issues/155