### PR TITLE
Feature/parent source

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.75",
+  "version": "1.0.76",
   "description": "Chameleon Software Development Kit",
   "author": "Chameleon Team <chameleon@nsoft.com>",
   "contributors": [

--- a/src/api/connector/index.js
+++ b/src/api/connector/index.js
@@ -72,8 +72,8 @@ export default {
       return result;
     });
   },
-  getSourceSchema(connector, source) {
+  getSourceSchema(connector, source, options) {
     const connectorType = this.getConnectorType(connector.type);
-    return connectorType.getSourceSchema(connector, source);
+    return connectorType.getSourceSchema(connector, source, options);
   },
 };

--- a/src/api/connector/internal/application.js
+++ b/src/api/connector/internal/application.js
@@ -82,6 +82,14 @@ const sourceSchemas = {
       operators: ['eq'],
     },
   },
+  parent: {
+    name: 'parent',
+    model: 'Parent',
+    actions: ['read'],
+    identifier: null,
+    fields: [],
+    filters: {},
+  },
 };
 
 const sourceMeta = {
@@ -117,6 +125,7 @@ const sourceMeta = {
     context: 'registry',
     path: '=$themes',
   },
+  parent: {},
 };
 
 export default {
@@ -143,8 +152,19 @@ export default {
       });
     });
   },
-  async getSourceSchema(connector, source) {
+  async getSourceSchema(connector, source, options) {
+    console.log(options);
+
     return new Promise((resolve, reject) => {
+      if (source.name === 'parent' && options.parent) {
+        const parentDataSource = options.parent.dataSource;
+        const schema = parentDataSource ? parentDataSource.schema : [];
+
+        return resolve({
+          schema,
+        });
+      }
+
       if (sourceSchemas[source.name]) {
         return resolve({
           schema: sourceSchemas[source.name],

--- a/src/api/connector/internal/application.js
+++ b/src/api/connector/internal/application.js
@@ -153,8 +153,6 @@ export default {
     });
   },
   async getSourceSchema(connector, source, options) {
-    console.log(options);
-
     return new Promise((resolve, reject) => {
       if (source.name === 'parent' && options.parent) {
         const parentDataSource = options.parent.dataSource;


### PR DESCRIPTION
Resolves #46 

Expanded Application Connector to retrieve `parent` source schema, from parent element (which is passed from Builder). This will make possible to add parent data source to Repeater Items in Repeater element itself.

Currently, there are no limits to where parent data source will be added to an element, but I potentially see this to be possible as an explicit allow `dataSource` option flag in child element. 🤷‍♂️ 

If parent has no `dataSource`, there will no schema, and therefore it will not be possible to choose the parent data source.