### PR TITLE
Add basic prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.78",
+  "version": "1.0.79",
   "description": "Chameleon Software Development Kit",
   "author": "Chameleon Team <chameleon@nsoft.com>",
   "contributors": [

--- a/src/api/connector/external/rest.js
+++ b/src/api/connector/external/rest.js
@@ -39,7 +39,7 @@ const getCommonParams = (connector) => {
   const authConfig = connector.options.auth;
   const basicAuthParams = authConfig.username && authConfig.password ? {
     headers: {
-      authorization: btoa(`${authConfig.username}:${authConfig.password}`),
+      authorization: `Basic ${btoa(`${authConfig.username}:${authConfig.password}`)}`,
     },
   } : {};
 


### PR DESCRIPTION
So, `Basic ` prefix is missing for basic authentication.