### PR TITLE
Change how is source merged when loading data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,8 +63,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -85,14 +84,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -107,20 +104,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -237,8 +231,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -250,7 +243,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -265,7 +257,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -273,14 +264,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -299,7 +288,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -380,8 +368,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -393,7 +380,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -479,8 +465,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -516,7 +501,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -536,7 +520,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -580,14 +563,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -618,8 +599,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.91",
+  "version": "1.0.92",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.91",
+  "version": "1.0.92",
   "description": "Chameleon Software Development Kit",
   "author": "Chameleon Team <chameleon@nsoft.com>",
   "contributors": [

--- a/src/mixins/sourceable.js
+++ b/src/mixins/sourceable.js
@@ -34,6 +34,22 @@ export default {
     },
   },
   methods: {
+    getMergedConnector() {
+      return assign(
+        {},
+        this.dataConnector,
+        this.options.connectors[this.dataConnector.id],
+      );
+    },
+    getMergedSource(connector) {
+      merge({},
+        connector.sources[this.dataSource.id],
+        {
+          schema: this.dataSource.schema,
+          filters: this.dataSource.filters,
+          meta: this.dataSource.meta,
+        });
+    },
     getMergedDataSourceParams() {
       return {
         params: merge(this.dataSourceParams, this.dataSource.params),
@@ -57,19 +73,8 @@ export default {
           });
         }
 
-        const connector = assign(
-          {},
-          this.dataConnector,
-          this.options.connectors[this.dataConnector.id],
-        );
-
-        const source = merge({},
-          connector.sources[this.dataSource.id],
-          {
-            schema: this.dataSource.schema,
-            filters: this.dataSource.filters,
-            meta: this.dataSource.meta,
-          });
+        const connector = this.getMergedConnector();
+        const source = this.getMergedSource(connector);
 
         this.loadingDataSource = true;
         return this.options.connector.getSourceData(

--- a/src/mixins/sourceable.js
+++ b/src/mixins/sourceable.js
@@ -42,13 +42,15 @@ export default {
       );
     },
     getMergedSource(connector) {
-      merge({},
+      return merge(
+        {},
         connector.sources[this.dataSource.id],
         {
           schema: this.dataSource.schema,
           filters: this.dataSource.filters,
           meta: this.dataSource.meta,
-        });
+        },
+      );
     },
     getMergedDataSourceParams() {
       return {

--- a/src/mixins/sourceable.js
+++ b/src/mixins/sourceable.js
@@ -63,10 +63,13 @@ export default {
           this.options.connectors[this.dataConnector.id],
         );
 
-        const source = merge({}, {
-          schema: this.dataSource.schema,
-          filters: this.dataSource.filters,
-        }, connector.sources[this.dataSource.id]);
+        const source = merge({},
+          connector.sources[this.dataSource.id],
+          {
+            schema: this.dataSource.schema,
+            filters: this.dataSource.filters,
+            meta: this.dataSource.meta,
+          });
 
         this.loadingDataSource = true;
         return this.options.connector.getSourceData(


### PR DESCRIPTION
`connector.sources[this.dataSource.id]` is source object from app connector instance. It needs to be merged with source that is saved on component.
`meta` is added so connectors like generic can have it applied from component data source since they don't have it on app connector instance level. Chameleon Data connectors should benefit from this, since meta that gets saved on component can have newer schema version than the one saved on app connector instance level, and it that case, newer version should be applied.