### PR TITLE
Feature/generic connector filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -84,12 +85,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -104,17 +107,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -231,7 +237,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -243,6 +250,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -257,6 +265,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -264,12 +273,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -288,6 +299,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -368,7 +380,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -380,6 +393,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -465,7 +479,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -501,6 +516,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -520,6 +536,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -563,12 +580,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -599,7 +618,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.92",
+  "version": "1.0.93",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7089,12 +7089,6 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
-    },
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -7288,6 +7282,12 @@
           "requires": {
             "mime-db": "~1.36.0"
           }
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
         },
         "safe-buffer": {
           "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.92",
+  "version": "1.0.93",
   "description": "Chameleon Software Development Kit",
   "author": "Chameleon Team <chameleon@nsoft.com>",
   "contributors": [

--- a/src/api/connector/external/rest.js
+++ b/src/api/connector/external/rest.js
@@ -3,7 +3,7 @@ import {
   toLower,
   assign,
   each,
-  omit,
+  omitBy,
   isNil,
 } from 'lodash';
 import { getSavedSources, getCommonMeta } from '../common';
@@ -31,7 +31,7 @@ const getCommonFilterQueryParams = (filterParams) => {
 
   const baseField = getFilterField(filterParams);
   const parsedParams = {
-    [baseField.name]: baseField.value,
+    [baseField.name]: [baseField.value],
   };
 
   each(filterParams.and, (filterParam) => {
@@ -40,9 +40,9 @@ const getCommonFilterQueryParams = (filterParams) => {
     const fieldValue = field.value;
 
     if (!parsedParams[fieldName]) {
-      parsedParams[fieldName] = fieldValue;
+      parsedParams[fieldName] = [fieldValue];
     } else {
-      parsedParams[fieldName] = `${parsedParams[fieldName]},${fieldValue}`;
+      parsedParams[fieldName].push(fieldValue);
     }
   });
 
@@ -91,7 +91,7 @@ const getClientParams = (optionParams = {}) => {
 
   clientParams.search = optionParams.search;
 
-  return omit(clientParams, isNil);
+  return omitBy(clientParams, isNil);
 };
 
 const getCommonParams = (connector) => {
@@ -170,6 +170,7 @@ export default {
 
     return http.get(url, assign(getCommonParams(connector), {
       params: assign(clientParams, filterParams),
+      paramsSerializer: uriParser.encode,
     })).then(response => response.data);
   },
   changeSourceData(connector, source, options) {

--- a/src/api/connector/external/rest.js
+++ b/src/api/connector/external/rest.js
@@ -1,5 +1,9 @@
 import http from 'axios';
-import { toLower, assign, each } from 'lodash';
+import {
+  toLower,
+  assign, each,
+  isEmpty,
+} from 'lodash';
 import { getSavedSources, getCommonMeta } from '../common';
 import { logger, uriParser } from '../../../utility';
 
@@ -147,7 +151,9 @@ export default {
     const { endpoint } = connector.options;
     const url = uriParser.joinUrl(endpoint, `/sources/${source.name}`);
     const clientParams = options && options.params ? getClientParams(options.params) : null;
-    const filterParams = getFilterQueryParams(source.filters[0], 'common');
+
+    const filterParams = !isEmpty(source.filters)
+      ? getFilterQueryParams(source.filters[0], 'common') : {};
 
     return http.get(url, assign(getCommonParams(connector), {
       params: assign(clientParams, filterParams),

--- a/src/api/connector/external/rest.js
+++ b/src/api/connector/external/rest.js
@@ -148,12 +148,14 @@ export default {
     ).then(response => enrichSchemaResponseWithMeta(response.data));
   },
   getSourceData(connector, source, options) {
+    console.log(connector, source, options);
     const { endpoint } = connector.options;
     const url = uriParser.joinUrl(endpoint, `/sources/${source.name}`);
     const clientParams = options && options.params ? getClientParams(options.params) : null;
+    const filterFormat = source.meta && source.meta.filterFormat ? source.meta.filterFormat : 'common';
 
     const filterParams = !isEmpty(source.filters)
-      ? getFilterQueryParams(source.filters[0], 'common') : {};
+      ? getFilterQueryParams(source.filters[0], filterFormat) : {};
 
     return http.get(url, assign(getCommonParams(connector), {
       params: assign(clientParams, filterParams),

--- a/src/api/connector/external/rest.spec.js
+++ b/src/api/connector/external/rest.spec.js
@@ -54,7 +54,12 @@ describe('rest connector', () => {
       name: 'articles',
     };
     rest.getSourceSchema(connectorMock, sourceMock).then((result) => {
-      expect(result).toEqual(sourceSchemaMock);
+      expect(result).toEqual({
+        ...sourceSchemaMock,
+        meta: {
+          filterFormat: 'common',
+        },
+      });
       done();
     });
   });

--- a/src/utility/uriParser.js
+++ b/src/utility/uriParser.js
@@ -1,10 +1,20 @@
+import { each, isArray } from 'lodash';
+
 export default {
   encode(params) {
-    return Object.keys(params).map((key) => {
-      const encoded = `${key}=${encodeURIComponent(params[key])}`;
+    const queryParams = new URLSearchParams();
 
-      return encoded;
-    }).join('&');
+    each(params, (paramValue, key) => {
+      if (isArray(paramValue)) { // multi-value query parameter
+        each(paramValue, (paramMultiValue) => {
+          queryParams.append(key, paramMultiValue);
+        });
+      } else {
+        queryParams.append(key, paramValue);
+      }
+    });
+
+    return queryParams.toString();
   },
   joinUrl(baseUrl, ...urlParts) {
     // Remove ending slash in base url

--- a/src/utility/uriParser.spec.js
+++ b/src/utility/uriParser.spec.js
@@ -13,6 +13,22 @@ describe('Uri parser utility', () => {
     expect(result).toEqual(expected);
   });
 
+  it('should properly handle encoding multi-value query params', () => {
+    const params = {
+      key1: 'value1',
+      key2: [
+        'value2',
+        'value3',
+      ],
+      key3: 'value4,withcomma',
+    };
+
+    const result = uriParser.encode(params);
+    const expected = 'key1=value1&key2=value2&key2=value3&key3=value4%2Cwithcomma';
+
+    expect(result).toEqual(expected);
+  });
+
   it('should properly join url base and parts without passed slashes', () => {
     const result = uriParser.joinUrl('https://example.com', 'api');
     const expected = 'https://example.com/api';

--- a/test/__data__/generic-http-source-schema.json
+++ b/test/__data__/generic-http-source-schema.json
@@ -16,6 +16,7 @@
       "type": "Date"
     }],
     "filters": {
+      "format": "common",
       "operators": ["eq"],
       "searchable": true
     }


### PR DESCRIPTION
Resolves #82.

Supported distinction between `common` and `extended` filtering, with appropriate parsing for both types. Made some related changes since:
- I needed source meta from schema to separate these two filtering types,
- I needed to support new multi-value param handling through multiple query parameters (will need to add it to docs): modified `uriParser`'s `encode` method, and expanded its tests for this case.