### PR TITLE
Binding value

### DIFF
--- a/src/mixins/bindable.spec.js
+++ b/src/mixins/bindable.spec.js
@@ -61,7 +61,7 @@ describe('bindable mixin', () => {
   it('ignores invalid dynamic value', () => {
     const value = '=element..myDynamicProp';
     const bindingValue = wrapper.vm.getBindingValue(value);
-    expect(bindingValue).toEqual(value);
+    expect(bindingValue).toEqual('');
   });
 
   it('resolves dynamic value', () => {

--- a/src/utility/binding.js
+++ b/src/utility/binding.js
@@ -39,7 +39,7 @@ export default {
     if (source) {
       return binding.split('.').reduce((o, i) => {
         if (o[i]) return o[i];
-        return value;
+        return '';
       }, source);
     }
 


### PR DESCRIPTION
When setting a binding string inside meta (as value) that can't be found on app initialisation I would get that same binding string (eg. activeLayout.name) inside option. With this fix we would show just an empty string, until we get the value we were looking for.